### PR TITLE
Use Services global variable

### DIFF
--- a/experiments/cachingfix/parent.js
+++ b/experiments/cachingfix/parent.js
@@ -16,8 +16,6 @@ var ex_cachingfix = class extends ExtensionCommon.ExtensionAPI {
       }
     }
     // Clear caches that could prevent upgrades from working properly
-    const { Services } = ChromeUtils.import(
-        "resource://gre/modules/Services.jsm");
     Services.obs.notifyObservers(null, "startupcache-invalidate", null);
   }
   getAPI(context) {


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm if the strict_min_version is 102.