### PR TITLE
Fix applyFilters call by adding empty aRawHeaders argument

### DIFF
--- a/experiments/filters/implementation.js
+++ b/experiments/filters/implementation.js
@@ -163,7 +163,7 @@ var filters = class extends ExtensionCommon.ExtensionAPI {
           //temporarily switch filter lists
           folder.setFilterList(tempFilterList);
           try {
-            filterService.applyFilters(Components.interfaces.nsMsgFilterType.All, [msg], folder, msgWindow);
+            filterService.applyFilters(Components.interfaces.nsMsgFilterType.All, [msg], [], folder, msgWindow);
           } finally {
             folder.setFilterList(curFilterList);
           }


### PR DESCRIPTION
After update to Thunderbird 150.0 the applyFilters function stopped working, because it didn't receive enough arguments.

Looking at the [source code](https://searchfox.org/comm-central/source/mailnews/search/public/nsIMsgFilterService.idl) we can see that it needs the aRawHeaders argument. As stated in the docstring "This list MUST be either empty or exactly match the size of aMsgHdrList.", thats why adding an empty array fixes the issue #13.

